### PR TITLE
feat: parse empty expressions statement as valid statements.

### DIFF
--- a/birdie_snapshots/error_in_parse_if_statement_missing_condition.accepted
+++ b/birdie_snapshots/error_in_parse_if_statement_missing_condition.accepted
@@ -6,7 +6,7 @@ test_name: should_not_parse_if_statement_missing_condition_test
 ---
 [
   Error(ParseError(
-    ExtraneousParenthesis,
+    ExtraneousParentheses,
     1,
   )),
 ]

--- a/birdie_snapshots/error_in_parse_invalid_condition_in_while_statement.accepted
+++ b/birdie_snapshots/error_in_parse_invalid_condition_in_while_statement.accepted
@@ -6,7 +6,7 @@ test_name: should_not_parse_while_statement_with_invalid_condition_test
 ---
 [
   Error(ParseError(
-    ExtraneousParenthesis,
+    ExtraneousParentheses,
     1,
   )),
 ]

--- a/birdie_snapshots/error_in_parse_while_statement_missing_condition.accepted
+++ b/birdie_snapshots/error_in_parse_while_statement_missing_condition.accepted
@@ -6,7 +6,7 @@ test_name: should_not_parse_while_statement_missing_condition_test
 ---
 [
   Error(ParseError(
-    ExtraneousParenthesis,
+    ExtraneousParentheses,
     1,
   )),
 ]

--- a/src/interpreter.gleam
+++ b/src/interpreter.gleam
@@ -58,6 +58,8 @@ fn execute_helper(
       let output = interpreter.io.write_stdout(types.inspect_object(obj))
       execute_helper(interpreter, rest, Ok(Some(output)))
     }
+    [stmt.EmptyExpression, ..rest] ->
+      execute_helper(interpreter, rest, Ok(None))
     [Expression(exp), ..rest] -> {
       let #(rst, interpreter) = evaluate(interpreter, exp)
       case rst {

--- a/src/parse.gleam
+++ b/src/parse.gleam
@@ -86,16 +86,17 @@ import gleam/option.{type Option, None, Some}
 import parse/error.{
   type LexicalError, type ParseError, ExpectExpression, ExpectLeftParentheses,
   ExpectLeftValue, ExpectRightParentheses, ExpectRightValue, ExpectSemicolon,
-  ExpectStatement, ExpectVariableName, ExtraneousParenthesis,
-  ExtraneousSemicolon, InvalidAssignmentTarget, LexError, LexicalError,
-  ParseError, UnexpectedToken,
+  ExpectStatement, ExpectVariableName, ExtraneousParentheses,
+  InvalidAssignmentTarget, LexError, LexicalError, ParseError, UnexpectedToken,
 }
 import parse/expr.{
   type Expr, Assign, Binary, Boolean, Grouping, LogicAnd, LogicOr, NegativeBool,
   NegativeNumber, NilLiteral, Number, String, Variable,
 }
 import parse/lexer.{type LexResult}
-import parse/stmt.{type Stmt, Block, Declaration, Expression, If, Print, While}
+import parse/stmt.{
+  type Stmt, Block, Declaration, EmptyExpression, Expression, If, Print, While,
+}
 import parse/token.{type Token, type TokenType, Token}
 import prelude.{with_ok}
 
@@ -407,8 +408,8 @@ fn expr_stmt(parser: Parser) -> #(Result(Option(Stmt)), Parser) {
       Ok(Some(Expression(expr))),
       advance(parser),
     )
-    Some(Token(token.Semicolon, line)), None -> #(
-      Error(ParseError(ExtraneousSemicolon, line)),
+    Some(Token(token.Semicolon, _)), None -> #(
+      Ok(Some(EmptyExpression)),
       advance(parser),
     )
 
@@ -642,7 +643,7 @@ fn primary(parser: Parser) -> #(Result(Option(Expr)), Parser) {
       }
 
     Some(Token(token.RightParen, line)) -> #(
-      Error(ParseError(ExtraneousParenthesis, line)),
+      Error(ParseError(ExtraneousParentheses, line)),
       parser,
     )
 

--- a/src/parse/error.gleam
+++ b/src/parse/error.gleam
@@ -46,8 +46,7 @@ pub type ParseErrorType {
   ExpectRightBrace
   ExpectVariableName
 
-  ExtraneousParenthesis
-  ExtraneousSemicolon
+  ExtraneousParentheses
 
   InvalidAssignmentTarget
 
@@ -81,13 +80,13 @@ pub fn inspect_parse_error(err: ParseError) -> String {
     ExpectVariableName ->
       "Expect variable name on line " <> int.to_string(err.line)
 
-    ExtraneousParenthesis ->
+    ExtraneousParentheses ->
       "Extraneous closing parenthesis \")\": " <> int.to_string(err.line)
-    ExtraneousSemicolon ->
-      "Extraneous semicolon \";\" after expression on line "
-      <> int.to_string(err.line)
-      <> ", please remove it"
 
+    // ExtraneousSemicolon ->
+    //   "Extraneous semicolon \";\" after expression on line "
+    //   <> int.to_string(err.line)
+    //   <> ", please remove it"
     UnexpectedToken(tok) ->
       "Unexpected token '"
       <> token.to_string(tok)

--- a/src/parse/stmt.gleam
+++ b/src/parse/stmt.gleam
@@ -5,6 +5,7 @@ import parse/token.{type Token}
 pub type Stmt {
   If(condition: Expr, then_branch: Stmt, else_branch: Option(Stmt))
   Block(statements: List(Stmt))
+  EmptyExpression
   Expression(expr: Expr)
   Print(expr: Expr)
   Declaration(name: Token, initializer: Option(Expr))

--- a/test/parser_test.gleam
+++ b/test/parser_test.gleam
@@ -9,8 +9,8 @@ import simplifile
 import parse
 import parse/error.{
   type ParseError, ExpectExpression, ExpectRightParentheses, ExpectRightValue,
-  ExpectSemicolon, ExpectVariableName, ExtraneousParenthesis,
-  ExtraneousSemicolon, ParseError, UnexpectedToken,
+  ExpectSemicolon, ExpectVariableName, ExtraneousParentheses, ParseError,
+  UnexpectedToken,
 }
 import parse/expr.{
   Binary, Boolean, Grouping, NegativeBool, NegativeNumber, NilLiteral, Number,
@@ -510,22 +510,8 @@ pub fn should_not_parse_missing_expression_test() {
   |> should.equal(expected_error)
 }
 
-pub fn should_not_parse_extraneous_semicolon_test() {
-  let expected_error = Error(ParseError(ExtraneousSemicolon, 1))
-  let expected_stmt = Ok(Some(stmt.Expression(Number(1.0))))
-
-  let parse_result =
-    [token.Number(1.0), token.Semicolon, token.Semicolon]
-    |> parse_wanted
-
-  should.be_true(
-    contains(parse_result, expected_error)
-    && contains(parse_result, expected_stmt),
-  )
-}
-
 pub fn should_not_parse_extraneous_parenthesis_test() {
-  let expected_error = Error(ParseError(ExtraneousParenthesis, 1))
+  let expected_error = Error(ParseError(ExtraneousParentheses, 1))
 
   let parse_result =
     [token.RightParen, token.Semicolon]


### PR DESCRIPTION
Add a new statement constructor `EmptyExpression` in order to parse empty expressions statement as valid statements. Fix typo in `ExtraneousParenthesis`.